### PR TITLE
Add scheduler and reminder commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 BOT_TOKEN="ENTER TOKEN"
 MONGO_URI="mongodb://localhost:27017"
 MONGO_DB="botdb"
+# Optional: needed only for manual slash command deployment
+CLIENT_ID=""

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 BOT_TOKEN="ENTER TOKEN"
+MONGO_URI="mongodb://localhost:27017"
+MONGO_DB="botdb"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,17 @@
 - **Example command setup can be found in [`src/Commands/info/ping.js`](https://github.com/memte/ExampleBot/blob/v14/src/Commands/info/ping.js).**  
   For more details, visit the [Discord.js Guide](https://discordjs.guide/slash-commands/advanced-creation.html).
 
-- **Note: Remember to configure your settings in the [`config.js`](https://github.com/memte/ExampleBot/blob/v14/src/Base/config.js) file and Don't forget to prepare a .env file in the same way as in [`.env.example`](https://github.com/memte/ExampleBot/blob/v14/.env.example)**!
+- **Note: Remember to configure your settings in the [`config.js`](https://github.com/memte/ExampleBot/blob/v14/src/Base/config.js) file and don't forget to prepare a `.env` file similar to [`.env.example`](https://github.com/memte/ExampleBot/blob/v14/.env.example)**!
+
+## Setup
+
+1. Copy `.env.example` to `.env` and provide your configuration values:
+   - `BOT_TOKEN` – Discord bot token
+   - `MONGO_URI` – MongoDB connection string
+   - `MONGO_DB` – database name
+   - `CLIENT_ID` *(optional)* – required only if you register commands without logging in
+
+The client ID is automatically derived from the token when the bot starts, so it's generally not needed unless you use a manual deployment script.
 
 ## Star History
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "license": "MIT",
   "dependencies": {
     "discord.js": "^14.21.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "mongodb": "^5.1.0",
+    "@discordjs/builders": "^1.6.0"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.45.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "discord.js": "^14.21.0",
     "winston": "^3.17.0",
     "mongodb": "^5.1.0",
-    "@discordjs/builders": "^1.6.0"
+    "@discordjs/builders": "^1.6.0",
+    "@discordjs/rest": "^1.6.0",
+    "discord-api-types": "^0.37.50"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.45.1"

--- a/src/Base/app.js
+++ b/src/Base/app.js
@@ -1,6 +1,7 @@
 import { Client, GatewayIntentBits, Partials } from "discord.js";
 import { readdirSync } from "node:fs";
 import config from "./config.js";
+import { loadPending } from "../Managers/scheduler.js";
 
 class BaseClient {
   constructor(token) {
@@ -22,6 +23,9 @@ class BaseClient {
 
   start() {
     this.loadHandlers();
+    this.client.once('ready', () => {
+      loadPending(this.client);
+    });
     this.client.login(this.token);
   }
 }

--- a/src/Base/database.js
+++ b/src/Base/database.js
@@ -1,0 +1,15 @@
+import { MongoClient } from "mongodb";
+
+const uri = process.env.MONGO_URI || "mongodb://localhost:27017";
+const dbName = process.env.MONGO_DB || "botdb";
+
+const client = new MongoClient(uri);
+let db;
+
+export async function connect() {
+  if (!client.topology || !client.topology.isConnected()) {
+    await client.connect();
+    db = client.db(dbName);
+  }
+  return db;
+}

--- a/src/Commands/reminders/remind.js
+++ b/src/Commands/reminders/remind.js
@@ -1,0 +1,47 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { addJob } from "../../Managers/reminderManager.js";
+import { getTimezone } from "../../Managers/timezone.js";
+import { parse } from "url";
+
+function parseTime(input, tz) {
+  input = input.trim();
+  const now = new Date();
+  if (input.startsWith("in")) {
+    const parts = input.split(/ +/);
+    const amount = parseInt(parts[1]);
+    const unit = parts[2];
+    if (unit.startsWith("min")) return new Date(now.getTime() + amount * 60000);
+    if (unit.startsWith("hour")) return new Date(now.getTime() + amount * 3600000);
+    if (unit.startsWith("day")) return new Date(now.getTime() + amount * 86400000);
+  }
+  const ts = Date.parse(input);
+  if (!isNaN(ts)) return new Date(ts);
+  return null;
+}
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("remind")
+    .setDescription("Remind another user")
+    .addUserOption((o) => o.setName("user").setDescription("Target user").setRequired(true))
+    .addStringOption((o) => o.setName("message").setDescription("Message").setRequired(true))
+    .addStringOption((o) => o.setName("time").setDescription("When to remind").setRequired(true)),
+  async slashRun(client, interaction) {
+    const user = interaction.options.getUser("user");
+    const message = interaction.options.getString("message");
+    const timeExp = interaction.options.getString("time");
+    const tz = await getTimezone(user.id);
+    const remindAt = parseTime(timeExp, tz);
+    if (!remindAt) {
+      return interaction.reply({ content: "Could not parse time.", ephemeral: true });
+    }
+    const job = await addJob(client, {
+      userId: user.id,
+      channelId: interaction.channelId,
+      message,
+      remindAt,
+      type: "reminder",
+    });
+    interaction.reply(`Reminder set for <@${user.id}> at <t:${Math.floor(remindAt.getTime()/1000)}:F>. id: ${job._id}`);
+  },
+};

--- a/src/Commands/reminders/remind.js
+++ b/src/Commands/reminders/remind.js
@@ -1,23 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { addJob } from "../../Managers/reminderManager.js";
 import { getTimezone } from "../../Managers/timezone.js";
-import { parse } from "url";
-
-function parseTime(input, tz) {
-  input = input.trim();
-  const now = new Date();
-  if (input.startsWith("in")) {
-    const parts = input.split(/ +/);
-    const amount = parseInt(parts[1]);
-    const unit = parts[2];
-    if (unit.startsWith("min")) return new Date(now.getTime() + amount * 60000);
-    if (unit.startsWith("hour")) return new Date(now.getTime() + amount * 3600000);
-    if (unit.startsWith("day")) return new Date(now.getTime() + amount * 86400000);
-  }
-  const ts = Date.parse(input);
-  if (!isNaN(ts)) return new Date(ts);
-  return null;
-}
+import { parseTimeExpression } from "../../Utils/timeUtils.js";
 
 export const commandBase = {
   slashData: new SlashCommandBuilder()
@@ -31,7 +15,7 @@ export const commandBase = {
     const message = interaction.options.getString("message");
     const timeExp = interaction.options.getString("time");
     const tz = await getTimezone(user.id);
-    const remindAt = parseTime(timeExp, tz);
+    const remindAt = parseTimeExpression(timeExp, tz);
     if (!remindAt) {
       return interaction.reply({ content: "Could not parse time.", ephemeral: true });
     }

--- a/src/Commands/reminders/remindme.js
+++ b/src/Commands/reminders/remindme.js
@@ -1,38 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { addJob } from "../../Managers/reminderManager.js";
 import { getTimezone } from "../../Managers/timezone.js";
-
-function parseTime(input, tz) {
-  input = input.trim();
-  const now = new Date();
-  const offset = 0; // naive: ignoring timezone difference
-  if (input.startsWith("in")) {
-    const parts = input.split(/ +/);
-    const amount = parseInt(parts[1]);
-    const unit = parts[2];
-    if (unit.startsWith("min")) return new Date(now.getTime() + amount * 60000);
-    if (unit.startsWith("hour")) return new Date(now.getTime() + amount * 3600000);
-    if (unit.startsWith("day")) return new Date(now.getTime() + amount * 86400000);
-  }
-  if (input.startsWith("tomorrow")) {
-    const time = input.split("at")[1].trim();
-    const [h, m] = time.split(":").map(Number);
-    const date = new Date(now.getTime() + 86400000);
-    date.setHours(h, m, 0, 0);
-    return date;
-  }
-  if (input.startsWith("at")) {
-    const time = input.split("at")[1].trim();
-    const [h, m] = time.split(":").map(Number);
-    const date = new Date(now);
-    date.setHours(h, m, 0, 0);
-    if (date < now) date.setDate(date.getDate() + 1);
-    return date;
-  }
-  const ts = Date.parse(input);
-  if (!isNaN(ts)) return new Date(ts);
-  return null;
-}
+import { parseTimeExpression } from "../../Utils/timeUtils.js";
 
 export const commandBase = {
   slashData: new SlashCommandBuilder()
@@ -51,7 +20,7 @@ export const commandBase = {
     const message = interaction.options.getString("message");
     const timeExp = interaction.options.getString("time");
     const tz = await getTimezone(interaction.user.id);
-    const remindAt = parseTime(timeExp, tz);
+    const remindAt = parseTimeExpression(timeExp, tz);
     if (!remindAt) {
       return interaction.reply({ content: "Could not parse time.", ephemeral: true });
     }

--- a/src/Commands/reminders/remindme.js
+++ b/src/Commands/reminders/remindme.js
@@ -1,0 +1,67 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { addJob } from "../../Managers/reminderManager.js";
+import { getTimezone } from "../../Managers/timezone.js";
+
+function parseTime(input, tz) {
+  input = input.trim();
+  const now = new Date();
+  const offset = 0; // naive: ignoring timezone difference
+  if (input.startsWith("in")) {
+    const parts = input.split(/ +/);
+    const amount = parseInt(parts[1]);
+    const unit = parts[2];
+    if (unit.startsWith("min")) return new Date(now.getTime() + amount * 60000);
+    if (unit.startsWith("hour")) return new Date(now.getTime() + amount * 3600000);
+    if (unit.startsWith("day")) return new Date(now.getTime() + amount * 86400000);
+  }
+  if (input.startsWith("tomorrow")) {
+    const time = input.split("at")[1].trim();
+    const [h, m] = time.split(":").map(Number);
+    const date = new Date(now.getTime() + 86400000);
+    date.setHours(h, m, 0, 0);
+    return date;
+  }
+  if (input.startsWith("at")) {
+    const time = input.split("at")[1].trim();
+    const [h, m] = time.split(":").map(Number);
+    const date = new Date(now);
+    date.setHours(h, m, 0, 0);
+    if (date < now) date.setDate(date.getDate() + 1);
+    return date;
+  }
+  const ts = Date.parse(input);
+  if (!isNaN(ts)) return new Date(ts);
+  return null;
+}
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("remindme")
+    .setDescription("Set a personal reminder")
+    .addStringOption((o) =>
+      o.setName("message").setDescription("Reminder message").setRequired(true),
+    )
+    .addStringOption((o) =>
+      o
+        .setName("time")
+        .setDescription('Time expression like "in 2 hours"')
+        .setRequired(true),
+    ),
+  async slashRun(client, interaction) {
+    const message = interaction.options.getString("message");
+    const timeExp = interaction.options.getString("time");
+    const tz = await getTimezone(interaction.user.id);
+    const remindAt = parseTime(timeExp, tz);
+    if (!remindAt) {
+      return interaction.reply({ content: "Could not parse time.", ephemeral: true });
+    }
+    const job = await addJob(client, {
+      userId: interaction.user.id,
+      channelId: null,
+      message,
+      remindAt,
+      type: "reminder",
+    });
+    interaction.reply({ content: `Reminder set for <t:${Math.floor(remindAt.getTime()/1000)}:F>. id: ${job._id}` });
+  },
+};

--- a/src/Commands/reminders/repeat.js
+++ b/src/Commands/reminders/repeat.js
@@ -1,0 +1,55 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { addJob } from "../../Managers/reminderManager.js";
+import { getTimezone } from "../../Managers/timezone.js";
+
+function nextFromRule(rule) {
+  const now = new Date();
+  if (rule.startsWith("every day")) {
+    const time = rule.split("at")[1].trim();
+    const [h, m] = time.split(":").map(Number);
+    const next = new Date(now);
+    next.setHours(h, m, 0, 0);
+    if (next <= now) next.setDate(next.getDate() + 1);
+    return next;
+  }
+  if (rule.startsWith("every")) {
+    const parts = rule.split(" ");
+    const day = parts[1].toLowerCase();
+    const time = parts[3];
+    const [h, m] = time.split(":").map(Number);
+    const next = new Date(now);
+    const dow = ["sun","mon","tue","wed","thu","fri","sat"].indexOf(day);
+    let diff = dow - next.getDay();
+    if (diff <= 0) diff += 7;
+    next.setDate(next.getDate() + diff);
+    next.setHours(h, m, 0, 0);
+    return next;
+  }
+  return null;
+}
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("repeat")
+    .setDescription("Create a recurring reminder")
+    .addStringOption((o) => o.setName("message").setDescription("Message").setRequired(true))
+    .addStringOption((o) => o.setName("rule").setDescription("Recurrence rule").setRequired(true)),
+  async slashRun(client, interaction) {
+    const message = interaction.options.getString("message");
+    const rule = interaction.options.getString("rule");
+    const tz = await getTimezone(interaction.user.id);
+    const next = nextFromRule(rule, tz);
+    if (!next) {
+      return interaction.reply({ content: "Could not parse rule.", ephemeral: true });
+    }
+    const job = await addJob(client, {
+      userId: interaction.user.id,
+      channelId: null,
+      message,
+      remindAt: next,
+      repeatRule: rule,
+      type: "reminder",
+    });
+    interaction.reply(`Recurring reminder set. Next: <t:${Math.floor(next.getTime()/1000)}:F>. id: ${job._id}`);
+  },
+};

--- a/src/Commands/reminders/repeat.js
+++ b/src/Commands/reminders/repeat.js
@@ -1,32 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { addJob } from "../../Managers/reminderManager.js";
 import { getTimezone } from "../../Managers/timezone.js";
-
-function nextFromRule(rule) {
-  const now = new Date();
-  if (rule.startsWith("every day")) {
-    const time = rule.split("at")[1].trim();
-    const [h, m] = time.split(":").map(Number);
-    const next = new Date(now);
-    next.setHours(h, m, 0, 0);
-    if (next <= now) next.setDate(next.getDate() + 1);
-    return next;
-  }
-  if (rule.startsWith("every")) {
-    const parts = rule.split(" ");
-    const day = parts[1].toLowerCase();
-    const time = parts[3];
-    const [h, m] = time.split(":").map(Number);
-    const next = new Date(now);
-    const dow = ["sun","mon","tue","wed","thu","fri","sat"].indexOf(day);
-    let diff = dow - next.getDay();
-    if (diff <= 0) diff += 7;
-    next.setDate(next.getDate() + diff);
-    next.setHours(h, m, 0, 0);
-    return next;
-  }
-  return null;
-}
+import { nextFromRule } from "../../Utils/timeUtils.js";
 
 export const commandBase = {
   slashData: new SlashCommandBuilder()
@@ -38,7 +13,7 @@ export const commandBase = {
     const message = interaction.options.getString("message");
     const rule = interaction.options.getString("rule");
     const tz = await getTimezone(interaction.user.id);
-    const next = nextFromRule(rule, tz);
+    const next = nextFromRule(rule, new Date(), tz);
     if (!next) {
       return interaction.reply({ content: "Could not parse rule.", ephemeral: true });
     }

--- a/src/Commands/settings/settimezone.js
+++ b/src/Commands/settings/settimezone.js
@@ -1,0 +1,14 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { setTimezone } from "../../Managers/timezone.js";
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("settimezone")
+    .setDescription("Set your timezone, e.g. UTC or UTC+2")
+    .addStringOption((o) => o.setName("zone").setDescription("Timezone").setRequired(true)),
+  async slashRun(client, interaction) {
+    const zone = interaction.options.getString("zone");
+    await setTimezone(interaction.user.id, zone);
+    interaction.reply({ content: `Timezone set to ${zone}`, ephemeral: true });
+  },
+};

--- a/src/Commands/tasks/addtask.js
+++ b/src/Commands/tasks/addtask.js
@@ -1,0 +1,34 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { addJob } from "../../Managers/reminderManager.js";
+import { getTimezone } from "../../Managers/timezone.js";
+
+function parseDate(input) {
+  const ts = Date.parse(input);
+  if (!isNaN(ts)) return new Date(ts);
+  return null;
+}
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("addtask")
+    .setDescription("Add a task with due date")
+    .addStringOption((o) => o.setName("description").setDescription("Description").setRequired(true))
+    .addStringOption((o) => o.setName("due").setDescription("Due date/time").setRequired(true)),
+  async slashRun(client, interaction) {
+    const desc = interaction.options.getString("description");
+    const dueStr = interaction.options.getString("due");
+    const tz = await getTimezone(interaction.user.id);
+    const due = parseDate(dueStr, tz);
+    if (!due) {
+      return interaction.reply({ content: "Could not parse due date.", ephemeral: true });
+    }
+    const job = await addJob(client, {
+      userId: interaction.user.id,
+      channelId: null,
+      message: `Task due: ${desc}`,
+      remindAt: due,
+      type: "task",
+    });
+    interaction.reply(`Task added for <t:${Math.floor(due.getTime()/1000)}:F>. id: ${job._id}`);
+  },
+};

--- a/src/Commands/tasks/addtask.js
+++ b/src/Commands/tasks/addtask.js
@@ -1,12 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { addJob } from "../../Managers/reminderManager.js";
 import { getTimezone } from "../../Managers/timezone.js";
-
-function parseDate(input) {
-  const ts = Date.parse(input);
-  if (!isNaN(ts)) return new Date(ts);
-  return null;
-}
+import { parseDateString } from "../../Utils/timeUtils.js";
 
 export const commandBase = {
   slashData: new SlashCommandBuilder()
@@ -18,7 +13,7 @@ export const commandBase = {
     const desc = interaction.options.getString("description");
     const dueStr = interaction.options.getString("due");
     const tz = await getTimezone(interaction.user.id);
-    const due = parseDate(dueStr, tz);
+    const due = parseDateString(dueStr, tz);
     if (!due) {
       return interaction.reply({ content: "Could not parse due date.", ephemeral: true });
     }

--- a/src/Commands/tasks/deletetask.js
+++ b/src/Commands/tasks/deletetask.js
@@ -1,0 +1,14 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { deleteJob } from "../../Managers/reminderManager.js";
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("deletetask")
+    .setDescription("Delete a task")
+    .addStringOption((o) => o.setName("id").setDescription("Task id").setRequired(true)),
+  async slashRun(client, interaction) {
+    const id = interaction.options.getString("id");
+    await deleteJob(id);
+    interaction.reply({ content: `Deleted task ${id}`, ephemeral: true });
+  },
+};

--- a/src/Commands/tasks/listtasks.js
+++ b/src/Commands/tasks/listtasks.js
@@ -1,0 +1,16 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { getUserJobs } from "../../Managers/reminderManager.js";
+
+export const commandBase = {
+  slashData: new SlashCommandBuilder()
+    .setName("listtasks")
+    .setDescription("List your pending tasks"),
+  async slashRun(client, interaction) {
+    const tasks = await getUserJobs(interaction.user.id, "task");
+    if (!tasks.length) {
+      return interaction.reply({ content: "No tasks.", ephemeral: true });
+    }
+    const lines = tasks.map((t) => `${t._id} - <t:${Math.floor(new Date(t.remindAt).getTime()/1000)}:F> - ${t.message}`);
+    interaction.reply({ content: lines.join("\n"), ephemeral: true });
+  },
+};

--- a/src/Managers/reminderManager.js
+++ b/src/Managers/reminderManager.js
@@ -1,0 +1,32 @@
+import { ObjectId } from "mongodb";
+import { connect } from "../Base/database.js";
+import { scheduleJob, cancelJob } from "./scheduler.js";
+
+export async function addJob(client, data) {
+  const db = await connect();
+  const job = {
+    userId: data.userId,
+    channelId: data.channelId || null,
+    message: data.message,
+    remindAt: data.remindAt,
+    createdAt: new Date(),
+    repeatRule: data.repeatRule || null,
+    type: data.type || "reminder",
+    status: "pending",
+  };
+  const res = await db.collection("jobs").insertOne(job);
+  job._id = res.insertedId;
+  scheduleJob(client, job);
+  return job;
+}
+
+export async function deleteJob(id) {
+  const db = await connect();
+  await db.collection("jobs").updateOne({ _id: new ObjectId(id) }, { $set: { status: "deleted" } });
+  cancelJob(id);
+}
+
+export async function getUserJobs(userId, type) {
+  const db = await connect();
+  return db.collection("jobs").find({ userId, type, status: "pending" }).toArray();
+}

--- a/src/Managers/scheduler.js
+++ b/src/Managers/scheduler.js
@@ -1,4 +1,5 @@
 import { connect } from "../Base/database.js";
+import { nextFromRule } from "../Utils/timeUtils.js";
 
 const timers = new Map();
 
@@ -39,7 +40,7 @@ async function executeJob(client, job) {
   }
 
   if (job.repeatRule) {
-    const next = computeNext(job.repeatRule, new Date(job.remindAt));
+    const next = nextFromRule(job.repeatRule, new Date(job.remindAt));
     if (next) {
       await db.collection("jobs").updateOne(
         { _id: job._id },
@@ -56,29 +57,6 @@ async function executeJob(client, job) {
   );
 }
 
-function computeNext(rule, date) {
-  // very naive rule parser: daily|weekly|monthly at HH:MM
-  const parts = rule.split(" ");
-  if (parts[0] === "daily") {
-    const [h, m] = parts[2].split(":").map(Number);
-    const next = new Date(date);
-    next.setDate(next.getDate() + 1);
-    next.setHours(h, m, 0, 0);
-    return next;
-  }
-  if (parts[0] === "weekly") {
-    const weekday = parts[1];
-    const [h, m] = parts[3].split(":").map(Number);
-    const next = new Date(date);
-    const dayOfWeek = ["sun","mon","tue","wed","thu","fri","sat"].indexOf(weekday.toLowerCase());
-    let diff = dayOfWeek - next.getDay();
-    if (diff <= 0) diff += 7;
-    next.setDate(next.getDate() + diff);
-    next.setHours(h, m, 0, 0);
-    return next;
-  }
-  return null;
-}
 
 export function cancelJob(id) {
   const timer = timers.get(id);

--- a/src/Managers/scheduler.js
+++ b/src/Managers/scheduler.js
@@ -1,0 +1,89 @@
+import { connect } from "../Base/database.js";
+
+const timers = new Map();
+
+export async function loadPending(client) {
+  const db = await connect();
+  const items = await db.collection("jobs").find({ status: "pending" }).toArray();
+  for (const job of items) {
+    scheduleJob(client, job);
+  }
+}
+
+export async function scheduleJob(client, job) {
+  const now = Date.now();
+  const wait = new Date(job.remindAt).getTime() - now;
+  if (wait <= 0) {
+    executeJob(client, job);
+  } else if (wait < 86400000) {
+    const timeout = setTimeout(() => executeJob(client, job), wait);
+    timers.set(job._id.toString(), timeout);
+  }
+}
+
+async function executeJob(client, job) {
+  const db = await connect();
+  if (job.type === "reminder" || job.type === "task") {
+    try {
+      const user = await client.users.fetch(job.userId);
+      const channel = job.channelId ? await client.channels.fetch(job.channelId) : null;
+      const content = job.message;
+      if (channel) {
+        channel.send(`<@${job.userId}> ${content}`);
+      } else {
+        user.send(content);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  if (job.repeatRule) {
+    const next = computeNext(job.repeatRule, new Date(job.remindAt));
+    if (next) {
+      await db.collection("jobs").updateOne(
+        { _id: job._id },
+        { $set: { remindAt: next } },
+      );
+      scheduleJob(client, { ...job, remindAt: next });
+      return;
+    }
+  }
+
+  await db.collection("jobs").updateOne(
+    { _id: job._id },
+    { $set: { status: "sent" } },
+  );
+}
+
+function computeNext(rule, date) {
+  // very naive rule parser: daily|weekly|monthly at HH:MM
+  const parts = rule.split(" ");
+  if (parts[0] === "daily") {
+    const [h, m] = parts[2].split(":").map(Number);
+    const next = new Date(date);
+    next.setDate(next.getDate() + 1);
+    next.setHours(h, m, 0, 0);
+    return next;
+  }
+  if (parts[0] === "weekly") {
+    const weekday = parts[1];
+    const [h, m] = parts[3].split(":").map(Number);
+    const next = new Date(date);
+    const dayOfWeek = ["sun","mon","tue","wed","thu","fri","sat"].indexOf(weekday.toLowerCase());
+    let diff = dayOfWeek - next.getDay();
+    if (diff <= 0) diff += 7;
+    next.setDate(next.getDate() + diff);
+    next.setHours(h, m, 0, 0);
+    return next;
+  }
+  return null;
+}
+
+export function cancelJob(id) {
+  const timer = timers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    timers.delete(id);
+  }
+}

--- a/src/Managers/timezone.js
+++ b/src/Managers/timezone.js
@@ -1,0 +1,12 @@
+import { connect } from "../Base/database.js";
+
+export async function setTimezone(userId, tz) {
+  const db = await connect();
+  await db.collection("timezones").updateOne({ userId }, { $set: { tz } }, { upsert: true });
+}
+
+export async function getTimezone(userId) {
+  const db = await connect();
+  const doc = await db.collection("timezones").findOne({ userId });
+  return doc ? doc.tz : "UTC";
+}

--- a/src/Utils/timeUtils.js
+++ b/src/Utils/timeUtils.js
@@ -1,0 +1,73 @@
+export function parseTzOffset(tz) {
+  const match = /^UTC([+-]?\d{1,2})?$/.exec(tz);
+  if (match && match[1]) return parseInt(match[1], 10) * 60;
+  return 0;
+}
+
+export function parseTimeExpression(input, tz = "UTC") {
+  const offset = parseTzOffset(tz);
+  const now = new Date();
+  const local = new Date(now.getTime() + offset * 60000);
+  input = input.trim().toLowerCase();
+  if (input.startsWith("in")) {
+    const parts = input.split(/ +/);
+    const amount = parseInt(parts[1], 10);
+    const unit = parts[2] || "minutes";
+    if (isNaN(amount)) return null;
+    if (unit.startsWith("min")) return new Date(local.getTime() + amount * 60000 - offset * 60000);
+    if (unit.startsWith("hour")) return new Date(local.getTime() + amount * 3600000 - offset * 60000);
+    if (unit.startsWith("day")) return new Date(local.getTime() + amount * 86400000 - offset * 60000);
+  }
+  if (input.startsWith("tomorrow")) {
+    const time = input.split("at")[1]?.trim() || "00:00";
+    const [h, m] = time.split(":").map((n) => parseInt(n, 10) || 0);
+    const date = new Date(local.getTime() + 86400000);
+    date.setHours(h, m, 0, 0);
+    return new Date(date.getTime() - offset * 60000);
+  }
+  if (input.startsWith("at")) {
+    const time = input.split("at")[1]?.trim() || "00:00";
+    const [h, m] = time.split(":").map((n) => parseInt(n, 10) || 0);
+    const date = new Date(local);
+    date.setHours(h, m, 0, 0);
+    if (date <= local) date.setDate(date.getDate() + 1);
+    return new Date(date.getTime() - offset * 60000);
+  }
+  const ts = Date.parse(input);
+  if (!isNaN(ts)) return new Date(ts);
+  return null;
+}
+
+export function parseDateString(input, tz = "UTC") {
+  return parseTimeExpression(input, tz);
+}
+
+export function nextFromRule(rule, from = new Date(), tz = "UTC") {
+  const offset = parseTzOffset(tz);
+  const local = new Date(from.getTime() + offset * 60000);
+  rule = rule.toLowerCase();
+  if (rule.startsWith("every day")) {
+    const time = rule.split("at")[1]?.trim() || "00:00";
+    const [h, m] = time.split(":").map((n) => parseInt(n, 10) || 0);
+    const next = new Date(local);
+    next.setHours(h, m, 0, 0);
+    if (next <= local) next.setDate(next.getDate() + 1);
+    return new Date(next.getTime() - offset * 60000);
+  }
+  if (rule.startsWith("every")) {
+    const parts = rule.split(/ +/);
+    const day = parts[1];
+    const time = parts[3] || "00:00";
+    const [h, m] = time.split(":").map((n) => parseInt(n, 10) || 0);
+    const next = new Date(local);
+    const dow = ["sun","mon","tue","wed","thu","fri","sat"].indexOf(day.slice(0,3));
+    if (dow !== -1) {
+      let diff = dow - next.getDay();
+      if (diff <= 0) diff += 7;
+      next.setDate(next.getDate() + diff);
+      next.setHours(h, m, 0, 0);
+      return new Date(next.getTime() - offset * 60000);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add Mongo connection samples to `.env.example`
- set up database access and job scheduler
- implement commands for reminders, tasks, recurring events and timezones
- queue existing jobs on bot startup

## Testing
- `npm start` *(fails: Cannot find package 'discord.js')*

------
https://chatgpt.com/codex/tasks/task_e_68810647b1bc8323800b5827951d74d8